### PR TITLE
Admin notify system

### DIFF
--- a/Content.Server/Administration/Systems/AdminNotifySystem.cs
+++ b/Content.Server/Administration/Systems/AdminNotifySystem.cs
@@ -1,0 +1,43 @@
+﻿using Content.Server.Chat.Managers;
+using Content.Shared.Mobs;
+using Robust.Server.GameObjects;
+
+namespace Content.Server.Administration.Systems;
+
+public sealed class AdminNotifySystem : EntitySystem
+{
+    [Dependency] private readonly IChatManager _chatManager = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    private void OnMobStateChanged(MobStateChangedEvent ev)
+    {
+        if (!TryComp(ev.Target, out ActorComponent? actorComponent))
+            return;
+
+        if (actorComponent.PlayerSession.AttachedEntity == null)
+            return;
+
+        string message;
+        if (ev.Origin == null)
+        {
+            message = Loc.GetString("notify-admin-mob-state-changed",
+                ("target", ToPrettyString(ev.Target)),
+                ("state", ev.NewMobState.ToString()));
+        }
+        else
+        {
+            message = Loc.GetString("notify-admin-mob-state-changed-by",
+                ("target", ToPrettyString(ev.Target)),
+                ("state", ev.NewMobState.ToString()),
+                ("origin", ToPrettyString(ev.Origin.Value)));
+        }
+
+        _chatManager.SendAdminAnnouncement(message);
+    }
+}

--- a/Content.Server/Administration/Systems/AdminNotifySystem.cs
+++ b/Content.Server/Administration/Systems/AdminNotifySystem.cs
@@ -20,7 +20,7 @@ public sealed class AdminNotifySystem : EntitySystem
         if (!TryComp(ev.Target, out ActorComponent? actorComponent))
             return;
 
-        if (actorComponent.PlayerSession.AttachedEntity == null)
+        if (actorComponent.PlayerSession.AttachedEntity == null || ev.NewMobState == MobState.Alive)
             return;
 
         string message;

--- a/Content.Shared/Mobs/Systems/MobStateSystem.StateMachine.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.StateMachine.cs
@@ -32,7 +32,7 @@ public partial class MobStateSystem
 
         var ev = new UpdateMobStateEvent {Target = entity, Component = component, Origin = origin};
         RaiseLocalEvent(entity, ref ev);
-        ChangeState(entity, component, ev.State);
+        ChangeState(entity, component, ev.State, origin);
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public partial class MobStateSystem
 
         var ev = new UpdateMobStateEvent {Target = entity, Component = component, Origin = origin};
         RaiseLocalEvent(entity, ref ev);
-        ChangeState(entity, component, ev.State);
+        ChangeState(entity, component, ev.State, origin);
     }
 
     #endregion

--- a/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
+++ b/Content.Shared/Mobs/Systems/MobThresholdSystem.cs
@@ -254,14 +254,14 @@ public sealed class MobThresholdSystem : EntitySystem
     #region Private Implementation
 
     private void CheckThresholds(EntityUid target, MobStateComponent mobStateComponent,
-        MobThresholdsComponent thresholdsComponent, DamageableComponent damageableComponent)
+        MobThresholdsComponent thresholdsComponent, DamageableComponent damageableComponent, EntityUid? origin = null)
     {
         foreach (var (threshold, mobState) in thresholdsComponent.Thresholds.Reverse())
         {
             if (damageableComponent.TotalDamage < threshold)
                 continue;
 
-            TriggerThreshold(target, mobState, mobStateComponent, thresholdsComponent);
+            TriggerThreshold(target, mobState, mobStateComponent, thresholdsComponent, origin);
             break;
         }
     }
@@ -270,7 +270,8 @@ public sealed class MobThresholdSystem : EntitySystem
         EntityUid target,
         MobState newState,
         MobStateComponent? mobState = null,
-        MobThresholdsComponent? thresholds = null)
+        MobThresholdsComponent? thresholds = null,
+        EntityUid? origin = null)
     {
         if (!Resolve(target, ref mobState, ref thresholds) ||
             mobState.CurrentState == newState)
@@ -279,7 +280,7 @@ public sealed class MobThresholdSystem : EntitySystem
         }
 
         thresholds.CurrentThresholdState = newState;
-        _mobStateSystem.UpdateMobState(target, mobState);
+        _mobStateSystem.UpdateMobState(target, mobState, origin);
 
         Dirty(target);
     }
@@ -328,7 +329,7 @@ public sealed class MobThresholdSystem : EntitySystem
     {
         if (!TryComp<MobStateComponent>(target, out var mobState))
             return;
-        CheckThresholds(target, mobState, thresholds, args.Damageable);
+        CheckThresholds(target, mobState, thresholds, args.Damageable, args.Origin);
         var ev = new MobThresholdChecked(target, mobState, thresholds, args.Damageable);
         RaiseLocalEvent(target, ref ev, true);
         UpdateAlerts(target, mobState.CurrentState, thresholds, args.Damageable);

--- a/Resources/Locale/ru-RU/Andromeda/administration/adminnotify.ftl
+++ b/Resources/Locale/ru-RU/Andromeda/administration/adminnotify.ftl
@@ -1,0 +1,2 @@
+﻿notify-admin-mob-state-changed = { $target } состояние меняется на { $state }.
+notify-admin-mob-state-changed-by = { $target } состояние меняется на { $state }. Причина: { $origin }.


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - они не будут видны в PR. -->

## Описание PR
Добавлена система уведомления админов, которая позволяет подписываться на события и уведомлять админов о них.
Сейчас реализовано уведомление о смене состояния игроков (->Critical, ->Dead).

:cl:
- add: Добавлена система уведомления админов
- tweak: Изменены сигнатури некоторых методов в MobStateSystem для проброса ID сущности, вызвавшой изменение состояния цели.
